### PR TITLE
pass predictableActionArguments to the xstate FSM

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   roots: ['<rootDir>/src'],
-  moduleNameMapper: { '^@src/(.$)$': '<rootDir>/src/$1' },
+  moduleNameMapper: {
+    '^@src/(.$)$': '<rootDir>/src/$1',
+    '\\.(css)$': 'identity-obj-proxy',
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@headlessui/react": "^1.5.0",
-        "@xstate/react": "^3.0.0",
+        "@xstate/react": "^3.2.1",
         "tslib": "^1.14.1",
-        "xstate": "^4.31.0"
+        "xstate": "^4.37.0"
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.0",
@@ -32,6 +32,7 @@
         "eslint-plugin-import-helpers": "^1.2.1",
         "eslint-plugin-react": "^7.29.4",
         "eslint-plugin-react-hooks": "^4.4.0",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^26",
         "postcss": "^8.4.12",
         "postcss-import": "^14.1.0",
@@ -1696,9 +1697,9 @@
       }
     },
     "node_modules/@xstate/react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.0.0.tgz",
-      "integrity": "sha512-KHSCfwtb8gZ7QH2luihvmKYI+0lcdHQOmGNRUxUEs4zVgaJCyd8csCEmwPsudpliLdUmyxX2pzUBojFkINpotw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.2.1.tgz",
+      "integrity": "sha512-L/mqYRxyBWVdIdSaXBHacfvS8NKn3sTKbPb31aRADbE9spsJ1p+tXil0GVQHPlzrmjGeozquLrxuYGiXsFNU7g==",
       "dependencies": {
         "use-isomorphic-layout-effect": "^1.0.0",
         "use-sync-external-store": "^1.0.0"
@@ -1706,7 +1707,7 @@
       "peerDependencies": {
         "@xstate/fsm": "^2.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "xstate": "^4.31.0"
+        "xstate": "^4.36.0"
       },
       "peerDependenciesMeta": {
         "@xstate/fsm": {
@@ -4483,6 +4484,12 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4685,6 +4692,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ignore": {
@@ -10176,9 +10195,9 @@
       "dev": true
     },
     "node_modules/xstate": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.31.0.tgz",
-      "integrity": "sha512-UK5m6OqUsTlPuKWkfRR5cR9/Yt7sysFyEg+PVIbEH9mwHSf9zuCvWO7rRvhBq7T+3pEXLKTEMfaqmLxl9Ob1pw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.37.0.tgz",
+      "integrity": "sha512-YC+JCerRclKS9ixQTuw8l3vs3iFqWzNzOGR0ID5XsSlieMXIV9nNPE43h9CGr7VdxA1QYhMwhCZA0EdpOd17Bg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -11501,9 +11520,9 @@
       }
     },
     "@xstate/react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.0.0.tgz",
-      "integrity": "sha512-KHSCfwtb8gZ7QH2luihvmKYI+0lcdHQOmGNRUxUEs4zVgaJCyd8csCEmwPsudpliLdUmyxX2pzUBojFkINpotw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@xstate/react/-/react-3.2.1.tgz",
+      "integrity": "sha512-L/mqYRxyBWVdIdSaXBHacfvS8NKn3sTKbPb31aRADbE9spsJ1p+tXil0GVQHPlzrmjGeozquLrxuYGiXsFNU7g==",
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0",
         "use-sync-external-store": "^1.0.0"
@@ -13588,6 +13607,12 @@
       "dev": true,
       "optional": true
     },
+    "harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -13740,6 +13765,15 @@
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ignore": {
@@ -17845,9 +17879,9 @@
       "dev": true
     },
     "xstate": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.31.0.tgz",
-      "integrity": "sha512-UK5m6OqUsTlPuKWkfRR5cR9/Yt7sysFyEg+PVIbEH9mwHSf9zuCvWO7rRvhBq7T+3pEXLKTEMfaqmLxl9Ob1pw=="
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.37.0.tgz",
+      "integrity": "sha512-YC+JCerRclKS9ixQTuw8l3vs3iFqWzNzOGR0ID5XsSlieMXIV9nNPE43h9CGr7VdxA1QYhMwhCZA0EdpOd17Bg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-import-helpers": "^1.2.1",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.4.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^26",
     "postcss": "^8.4.12",
     "postcss-import": "^14.1.0",
@@ -74,8 +75,8 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.5.0",
-    "@xstate/react": "^3.0.0",
+    "@xstate/react": "^3.2.1",
     "tslib": "^1.14.1",
-    "xstate": "^4.31.0"
+    "xstate": "^4.37.0"
   }
 }

--- a/src/FeatureState.tsx
+++ b/src/FeatureState.tsx
@@ -95,7 +95,7 @@ export const FeatureMachine = createMachine<FeatureContext, FeatureAction, Featu
   id: 'feature',
   initial: 'initial',
   context: {},
-
+  predictableActionArguments: true,
   on: {
     ENABLE: [
       { target: 'asyncEnabled', cond: (ctx) => ctx.featureDesc?.onChangeDefault != null },

--- a/src/FeaturesState.tsx
+++ b/src/FeaturesState.tsx
@@ -44,6 +44,7 @@ export function valueOfFeature(featuresState: FeaturesState, feature: string): [
 export const FeaturesMachine = createMachine<FeaturesContext, FeaturesAction, FeaturesTypeState>({
   id: 'features',
   initial: 'idle',
+  predictableActionArguments: true,
   context: {
     features: {},
   },


### PR DESCRIPTION
A couple of smaller changes in the PR:

* Maps the `src/tailwind.css` file to `identity-obj-proxy` to get the Jest test suite to work
* Bump the versions on `xstate` and `@xstate/react` since the current versions don't seem to support the type definitions for `predictableActionArguments`
* Passes `predictableActionArguments` in to the Xstate machines

I've not updated the build artifacts in this PR as I recon those are compiled in separate build commits?